### PR TITLE
examples(vitepress): fix next page by removing extra slash

### DIFF
--- a/integrations/vitepress/.vitepress/config.mts
+++ b/integrations/vitepress/.vitepress/config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
     sidebar: [
       {
         text: "API",
-        link: "/api/",
+        link: "/api",
         items: typedocSidebar,
       },
     ],


### PR DESCRIPTION
I think this is broking next page navigation see https://github.com/vuejs/vitepress/issues/3031#issuecomment-2203650743
I never used `vitepress` and just tried your example, and landed on this.